### PR TITLE
Update S3 bucket name to MCP-DEMO-2025

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,10 +3,10 @@ provider "aws" {
 }
 
 resource "aws_s3_bucket" "private_bucket" {
-  bucket = "mcp-demo-1804"
+  bucket = "mcp-demo-2025"
 
   tags = {
-    Name        = "MCP-Demo-1804"
+    Name        = "MCP-DEMO-2025"
     Environment = var.environment
     Terraform   = "true"
   }


### PR DESCRIPTION
## Description

This pull request updates the S3 bucket name from `MCP-Demo-1804` to `MCP-DEMO-2025`.

### Changes Made:
- Changed the bucket name in the `aws_s3_bucket` resource from `mcp-demo-1804` to `mcp-demo-2025`
- Updated the Name tag from `MCP-Demo-1804` to `MCP-DEMO-2025`

### Testing:
- The GitHub Actions workflow will automatically run Terraform plan on this PR to verify the changes.
- The plan should show that the existing S3 bucket will be destroyed and a new one with the updated name will be created.

### Note:
This change will cause the existing S3 bucket to be destroyed and recreated with the new name. Make sure to back up any important data before merging this PR.