### PR TITLE
Add static website hosting with CloudFront distribution

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,19 +2,20 @@ provider "aws" {
   region = var.aws_region
 }
 
-resource "aws_s3_bucket" "private_bucket" {
-  bucket = "mcp-demo-2025"
+# S3 bucket for static website hosting
+resource "aws_s3_bucket" "website_bucket" {
+  bucket = var.bucket_name
 
   tags = {
-    Name        = "MCP-DEMO-2025"
+    Name        = var.bucket_name
     Environment = var.environment
     Terraform   = "true"
   }
 }
 
 # Block all public access to the bucket
-resource "aws_s3_bucket_public_access_block" "private_bucket_access" {
-  bucket = aws_s3_bucket.private_bucket.id
+resource "aws_s3_bucket_public_access_block" "website_bucket_access" {
+  bucket = aws_s3_bucket.website_bucket.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -22,9 +23,22 @@ resource "aws_s3_bucket_public_access_block" "private_bucket_access" {
   restrict_public_buckets = true
 }
 
+# Enable static website hosting
+resource "aws_s3_bucket_website_configuration" "website_config" {
+  bucket = aws_s3_bucket.website_bucket.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+}
+
 # Server-side encryption configuration
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption" {
-  bucket = aws_s3_bucket.private_bucket.id
+  bucket = aws_s3_bucket.website_bucket.id
 
   rule {
     apply_server_side_encryption_by_default {
@@ -35,9 +49,91 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption
 
 # Versioning configuration
 resource "aws_s3_bucket_versioning" "bucket_versioning" {
-  bucket = aws_s3_bucket.private_bucket.id
+  bucket = aws_s3_bucket.website_bucket.id
   
   versioning_configuration {
     status = "Enabled"
+  }
+}
+
+# S3 bucket policy to allow access from CloudFront
+resource "aws_s3_bucket_policy" "website_bucket_policy" {
+  bucket = aws_s3_bucket.website_bucket.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontServicePrincipal"
+        Effect    = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.website_bucket.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.s3_distribution.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+# CloudFront Origin Access Control
+resource "aws_cloudfront_origin_access_control" "oac" {
+  name                              = "${var.bucket_name}-oac"
+  description                       = "Origin Access Control for ${var.bucket_name}"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# CloudFront distribution
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  origin {
+    domain_name              = aws_s3_bucket.website_bucket.bucket_regional_domain_name
+    origin_id                = "S3-${var.bucket_name}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  price_class         = "PriceClass_100"
+  comment             = "CloudFront distribution for ${var.bucket_name}"
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "S3-${var.bucket_name}"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = {
+    Name        = "${var.bucket_name}-distribution"
+    Environment = var.environment
+    Terraform   = "true"
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,29 @@
 output "bucket_id" {
   description = "The name of the bucket"
-  value       = aws_s3_bucket.private_bucket.id
+  value       = aws_s3_bucket.website_bucket.id
 }
 
 output "bucket_arn" {
   description = "The ARN of the bucket"
-  value       = aws_s3_bucket.private_bucket.arn
+  value       = aws_s3_bucket.website_bucket.arn
 }
 
-output "bucket_domain_name" {
-  description = "The bucket domain name"
-  value       = aws_s3_bucket.private_bucket.bucket_domain_name
+output "bucket_website_endpoint" {
+  description = "The website endpoint of the bucket"
+  value       = aws_s3_bucket_website_configuration.website_config.website_endpoint
 }
 
-output "bucket_regional_domain_name" {
-  description = "The bucket region-specific domain name"
-  value       = aws_s3_bucket.private_bucket.bucket_regional_domain_name
+output "cloudfront_distribution_id" {
+  description = "The ID of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.s3_distribution.id
+}
+
+output "cloudfront_distribution_domain_name" {
+  description = "The domain name of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.s3_distribution.domain_name
+}
+
+output "cloudfront_distribution_arn" {
+  description = "The ARN of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.s3_distribution.arn
 }

--- a/sample-website/error.html
+++ b/sample-website/error.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Error - MCP Static Website</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            color: #333;
+            background-color: #f4f4f4;
+        }
+        .container {
+            width: 80%;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+        header {
+            background: #cc0000;
+            color: #fff;
+            padding: 1rem 0;
+            text-align: center;
+        }
+        .content {
+            background: #fff;
+            padding: 2rem;
+            margin-top: 2rem;
+            border-radius: 5px;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+        }
+        footer {
+            text-align: center;
+            margin-top: 2rem;
+            padding: 1rem 0;
+            background: #333;
+            color: #fff;
+        }
+        .error-icon {
+            font-size: 4rem;
+            text-align: center;
+            margin: 1rem 0;
+        }
+        .btn {
+            display: inline-block;
+            background: #0066cc;
+            color: #fff;
+            padding: 0.5rem 1rem;
+            text-decoration: none;
+            border-radius: 3px;
+            margin-top: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Error - Page Not Found</h1>
+        </div>
+    </header>
+    
+    <div class="container">
+        <div class="content">
+            <div class="error-icon">404</div>
+            <h2>Oops! The page you're looking for doesn't exist.</h2>
+            <p>We're sorry, but the page you requested could not be found on our server.</p>
+            <p>Please check the URL for any mistakes and try again.</p>
+            <a href="index.html" class="btn">Go to Homepage</a>
+        </div>
+    </div>
+    
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 MCP Static Website Demo</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/sample-website/index.html
+++ b/sample-website/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MCP Static Website</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            color: #333;
+            background-color: #f4f4f4;
+        }
+        .container {
+            width: 80%;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+        header {
+            background: #0066cc;
+            color: #fff;
+            padding: 1rem 0;
+            text-align: center;
+        }
+        .content {
+            background: #fff;
+            padding: 2rem;
+            margin-top: 2rem;
+            border-radius: 5px;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+        }
+        footer {
+            text-align: center;
+            margin-top: 2rem;
+            padding: 1rem 0;
+            background: #333;
+            color: #fff;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Welcome to MCP Static Website</h1>
+        </div>
+    </header>
+    
+    <div class="container">
+        <div class="content">
+            <h2>Hello from AWS CloudFront and S3!</h2>
+            <p>This is a sample static website hosted on Amazon S3 and delivered through Amazon CloudFront.</p>
+            <p>The infrastructure for this website was created using Terraform.</p>
+            
+            <h3>Features of this setup:</h3>
+            <ul>
+                <li>Private S3 bucket with static website hosting enabled</li>
+                <li>CloudFront distribution for secure content delivery</li>
+                <li>Infrastructure as Code using Terraform</li>
+                <li>Automated deployment through GitHub Actions</li>
+            </ul>
+        </div>
+    </div>
+    
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 MCP Static Website Demo</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/upload-website.tf
+++ b/upload-website.tf
@@ -1,0 +1,21 @@
+# Upload index.html to S3
+resource "aws_s3_object" "index_html" {
+  bucket       = aws_s3_bucket.website_bucket.id
+  key          = "index.html"
+  source       = "${path.module}/sample-website/index.html"
+  content_type = "text/html"
+  etag         = filemd5("${path.module}/sample-website/index.html")
+
+  depends_on = [aws_s3_bucket.website_bucket]
+}
+
+# Upload error.html to S3
+resource "aws_s3_object" "error_html" {
+  bucket       = aws_s3_bucket.website_bucket.id
+  key          = "error.html"
+  source       = "${path.module}/sample-website/error.html"
+  content_type = "text/html"
+  etag         = filemd5("${path.module}/sample-website/error.html")
+
+  depends_on = [aws_s3_bucket.website_bucket]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,3 +9,9 @@ variable "environment" {
   type        = string
   default     = "dev"
 }
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket for static website hosting"
+  type        = string
+  default     = "mcp-static-website-2025"
+}


### PR DESCRIPTION
## Description

This pull request adds Terraform configuration to create a private S3 bucket configured for static website hosting along with a CloudFront distribution to securely serve the content.

### Changes Made:

1. **S3 Bucket Configuration**:
   - Created a private S3 bucket with static website hosting enabled
   - Added bucket policy to allow access only from CloudFront
   - Configured server-side encryption and versioning

2. **CloudFront Distribution**:
   - Set up CloudFront distribution with Origin Access Control
   - Configured cache behaviors and viewer protocols
   - Set up proper security settings

3. **Sample Website**:
   - Added sample HTML files (index.html and error.html)
   - Added Terraform configuration to upload these files to S3

4. **Variables and Outputs**:
   - Updated variables.tf with configurable bucket name
   - Added outputs for CloudFront domain and other useful information

### Testing:

After applying this Terraform configuration:
1. The S3 bucket will be private (no public access)
2. The website will be accessible via the CloudFront domain name
3. The CloudFront distribution will serve the content securely over HTTPS

### Notes:

- The default bucket name is set to "mcp-static-website-2025" but can be changed via variables
- The CloudFront distribution uses the default CloudFront certificate for simplicity